### PR TITLE
feat: add compression flags support + older version support (unpack only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +172,21 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crossbeam-deque"
@@ -301,6 +322,8 @@ dependencies = [
  "assert_fs",
  "clap",
  "hex-literal",
+ "lzma-rs",
+ "lzs",
  "nom",
  "predicates",
  "thiserror",
@@ -330,6 +353,25 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a6ea15aaeaee014ac5398e8b2a01da256e3274d8074c7b413093ff11ce554f"
+dependencies = [
+ "void",
+]
 
 [[package]]
 name = "memchr"
@@ -559,6 +601,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ clap = { version = "4.5.32", features = ["derive"] }
 thiserror = "2.0.12"
 walkdir = "2.5.0"
 nom = "8.0.0"
+lzs = { version = "0.1.1", default-features = false, features = ["std"] }
+lzma-rs = "0.3.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Section repeated for each file inside the archive
 | 0x00 | 2 | Length of this section (`filepath_length + 20`) |
 | 0x02 | 2 | Length of the file path |
 | 0x04 | L | File path in unicode UTF16 |
-| 0x04 + L  | 4 | File flags (`0`: Non-compressed, other unimplemented) |
-| 0x04 + L + 0x04 | 8 | IRO archive offset pointing to the related file in data section |
+| 0x04 + L  | 4 | File flags (`0`: Non-compressed, `1`: LZSS-compressed, `2`: LZMA-compressed) |
+| 0x04 + L + 0x04 | 8 | IRO archive offset pointing to the related file in data section (Size=4 on version 0x10000) |
 | 0x04 + L + 0x0C | 4 | Length of the data |
 
 ### Data section

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,0 +1,51 @@
+use lzs::{Lzs, LzsError};
+use nom::number::complete::le_i32;
+use lzma_rs::error::Error as LzmaError;
+
+use crate::Error;
+
+pub fn lzss_decompress<R: std::io::Read, W: std::io::Write>(
+    mut reader: R,
+    mut writer: W
+) -> Result<(), Error> {
+    match Lzs::new(0x00).decompress(
+        lzs::IOSimpleReader::new(&mut reader),
+        lzs::IOSimpleWriter::new(&mut writer),
+    ) {
+        Err(LzsError::ReadError(e)) => Err(Error::Io(e)),
+        Err(LzsError::WriteError(e)) => Err(Error::Io(e)),
+        Ok(()) => Ok(()),
+    }
+}
+
+pub fn lzma_decompress<R: std::io::Read, W: std::io::Write>(
+    mut reader: R,
+    mut writer: W
+) -> Result<(), Error> {
+    let mut header_bytes = [0u8; 8];
+    reader.read_exact(&mut header_bytes)?;
+    let bytes: &[u8] = &mut header_bytes;
+    let (bytes, dec_size) = le_i32(bytes)?;
+    let (_, prop_size) = le_i32(bytes)?;
+    let mut buf_reader = std::io::BufReader::new(&mut reader);
+    match if prop_size < 5 {
+        lzma_rs::lzma2_decompress(&mut buf_reader, &mut writer)
+    } else {
+        let options = lzma_rs::decompress::Options {
+            unpacked_size: lzma_rs::decompress::UnpackedSize::UseProvided(Some(dec_size as u64)),
+            allow_incomplete: false,
+            memlimit: None,
+        };
+        lzma_rs::lzma_decompress_with_options(&mut buf_reader, &mut writer, &options)
+    } {
+        Err(LzmaError::IoError(e)) => Err(Error::Io(e)),
+        Err(LzmaError::HeaderTooShort(e)) => Err(Error::Io(e)),
+        Err(LzmaError::LzmaError(s)) => {
+            Err(Error::Io(std::io::Error::new(std::io::ErrorKind::Other, s)))
+        },
+        Err(LzmaError::XzError(s)) => {
+            Err(Error::Io(std::io::Error::new(std::io::ErrorKind::Other, s)))
+        },
+        Ok(()) => Ok(()),
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,6 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
-use crate::iro_header::{IroFlags, IroVersion};
-
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -31,10 +29,6 @@ pub enum Error {
     InvalidUtf16(String),
     #[error("parent file path does not exists: {0}")]
     ParentPathDoesNotExist(PathBuf),
-    #[error("unsupporter iro version {0}")]
-    UnsupportedIroVersion(IroVersion),
-    #[error("unsupporter iro flags {0}")]
-    UnsupportedIroFlags(IroFlags),
 }
 
 impl From<nom::Err<nom::error::Error<&[u8]>>> for Error {

--- a/src/iro_entry.rs
+++ b/src/iro_entry.rs
@@ -13,6 +13,8 @@ pub struct IroEntry {
 #[derive(Debug)]
 pub enum FileFlags {
     Uncompressed = 0,
+    LzssCompressed = 1,
+    LzmaCompressed = 2,
 }
 
 impl IroEntry {
@@ -45,7 +47,9 @@ impl TryFrom<i32> for FileFlags {
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(FileFlags::Uncompressed),
-            _ => Err(Error::InvalidFileFlags(value))
+            1 => Ok(FileFlags::LzssCompressed),
+            2 => Ok(FileFlags::LzmaCompressed),
+            _ => Err(Error::InvalidFileFlags(value)),
         }
     }
 }

--- a/src/iro_parser.rs
+++ b/src/iro_parser.rs
@@ -23,11 +23,16 @@ pub fn parse_iro_header_v2(bytes: &[u8]) -> Result<(&[u8], IroHeader), Error> {
 }
 
 /// Parse IroEntry without considering length of entire block
-pub fn parse_iro_entry_v2(bytes: &[u8]) -> Result<(&[u8], IroEntry), Error> {
+pub fn parse_iro_entry_v2<'a>(header: &IroHeader, bytes: &'a [u8]) -> Result<(&'a [u8], IroEntry), Error> {
     let (bytes, filepath_len) = le_u16(bytes)?;
     let (bytes, filepath) = take(filepath_len)(bytes)?;
     let (bytes, file_flags) = le_i32(bytes)?;
-    let (bytes, offset) = le_u64(bytes)?;
+    let (bytes, offset) = if header.version == IroVersion::Zero {
+        let (bytes, offset) = le_u32(bytes)?;
+        (bytes, offset as u64)
+    } else {
+        le_u64(bytes)?
+    };
     let (bytes, data_len) = le_u32(bytes)?;
 
     Ok((

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -202,6 +202,90 @@ pub fn unpack_multiple_files() {
     dir.close().unwrap();
 }
 
+#[test]
+pub fn unpack_lzss_compressed() {
+    let iro_bytes: &[u8] = &hex!(
+        "49 52 4f 53 02 00 01 00   00 00 00 00 10 00 00 00"
+        "01 00 00 00 24 00 10 00   66 00 69 00 6c 00 65 00"
+        "2e 00 74 00 78 00 74 00   01 00 00 00 38 00 00 00"
+        "00 00 00 00 2D 00 00 00   FF 3C 3F 78 6D 6C 20 76"
+        "65 FF 72 73 69 6F 6E 3D   22 31 FF 2E 30 22 20 65"
+        "6E 63 6F FF 64 69 6E 67   3D 22 75 74 FF 66 2D 38"
+        "22 3F 3E 0D 0A                                   "
+    );
+    let dir = assert_fs::TempDir::new().unwrap();
+    dir.child("lzss_compressed.iro")
+        .write_binary(iro_bytes)
+        .unwrap();
+
+    iroga_cmd()
+        .current_dir(dir.path())
+        .arg("unpack")
+        .arg(dir.path().join("lzss_compressed.iro"))
+        .assert()
+        .success()
+        .code(0);
+
+    assert!(dir.child("lzss_compressed/file.txt").exists());
+    dir.child("lzss_compressed/file.txt").assert("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n");
+    dir.close().unwrap();
+}
+
+#[test]
+pub fn unpack_lzma_compressed() {
+    let iro_bytes: &[u8] = &hex!(
+        "49 52 4f 53 02 00 01 00   00 00 00 00 10 00 00 00"
+        "01 00 00 00 24 00 10 00   66 00 69 00 6c 00 65 00"
+        "2e 00 74 00 78 00 74 00   02 00 00 00 38 00 00 00"
+        "00 00 00 00 28 00 00 00   2E 00 00 00 05 00 00 00"
+        "5D 00 00 10 00 00 24 19   49 98 6F 10 11 C8 5F E6"
+        "D5 8A 64 78 4D FA BB C3   D4 DE 60 B7 5A 52 38 00"
+    );
+    let dir = assert_fs::TempDir::new().unwrap();
+    dir.child("lzma_compressed.iro")
+        .write_binary(iro_bytes)
+        .unwrap();
+
+    iroga_cmd()
+        .current_dir(dir.path())
+        .arg("unpack")
+        .arg(dir.path().join("lzma_compressed.iro"))
+        .assert()
+        .success()
+        .code(0);
+
+    assert!(dir.child("lzma_compressed/file.txt").exists());
+    dir.child("lzma_compressed/file.txt").assert("Hello World!\r\n\r\nHi!\r\n\r\nHello World!\r\n\r\nHi!\r\n\r\n");
+    dir.close().unwrap();
+}
+
+#[test]
+pub fn unpack_version_0() {
+    let iro_bytes: &[u8] = &hex!(
+        "49 52 4f 53 00 00 01 00   00 00 00 00 10 00 00 00"
+        "01 00 00 00 20 00 10 00   66 00 69 00 6c 00 65 00"
+        "2e 00 74 00 78 00 74 00   00 00 00 00 34 00 00 00"
+        "17 00 00 00 48 65 6c 6c   6f 20 57 6f 72 6c 64 21"
+        "0d 0a 0d 0a 48 69 21 0d   0a 0d 0a               "
+    );
+    let dir = assert_fs::TempDir::new().unwrap();
+    dir.child("version_0.iro")
+        .write_binary(iro_bytes)
+        .unwrap();
+
+    iroga_cmd()
+        .current_dir(dir.path())
+        .arg("unpack")
+        .arg(dir.path().join("version_0.iro"))
+        .assert()
+        .success()
+        .code(0);
+
+    assert!(dir.child("version_0/file.txt").exists());
+    dir.child("version_0/file.txt").assert("Hello World!\r\n\r\nHi!\r\n\r\n");
+    dir.close().unwrap();
+}
+
 fn iroga_cmd() -> Command {
     Command::cargo_bin("iroga").unwrap()
 }


### PR DESCRIPTION
Allow to unpack compressed IRO entries and old IROs with version = `0x10000`.

Two optional dependencies are added:
- lzs (my fork from lzss, which was not the right algorithm, see https://github.com/alexkazik/lzss/issues/4
- lzma-rs

Those dependencies are enabled by default