### PR TITLE
Add iro_archive public module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Command line application to pack a single directory into an IRO archive.
 The IRO archive is a format used in [7th heaven](https://github.com/tsunamods-codes/7th-Heaven), a FF7 mod manager application
 
-## Usage
+## CLI Usage
 
 ```sh
 # Simple usage
@@ -12,6 +12,26 @@ iroga pack <DIR>
 
 # For help information
 iroga --help
+```
+
+## Lib Usage
+
+```rust
+use iroga::error::Error;
+use iroga::iro_archive::IroArchive;
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::Path;
+
+let iro_file = File::open(Path::new("foobar.iro"))?;
+let mut iro_archive = IroArchive::open(iro_file);
+let iro_header = iro_archive.read_header()?;
+let iro_entries = iro_archive.read_iro_entries(&iro_header)?;
+
+for iro_entry in iro_entries {
+    let mut buf_writer = BufWriter::new(Vec::new());
+    iro_archive.seek_and_read_file_entry(&iro_entry, &mut buf_writer)?;
+}
 ```
 
 ## IRO format

--- a/src/iro_archive.rs
+++ b/src/iro_archive.rs
@@ -1,0 +1,61 @@
+use std::{
+    io::{BufReader, Read, Seek, Write},
+    result::Result,
+};
+
+use crate::Error;
+use crate::compression;
+use crate::iro_entry::{FileFlags, IroEntry};
+use crate::iro_header::IroHeader;
+use crate::iro_parser::{parse_iro_entry_v2, parse_iro_header_v2};
+
+pub struct IroArchive<RW> {
+    stream: RW,
+}
+
+impl<R: Read + Seek> IroArchive<R> {
+    pub fn open(stream: R) -> Self {
+        IroArchive { stream }
+    }
+
+    pub fn read_header(&mut self) -> Result<IroHeader, Error> {
+        let mut iro_header_bytes = [0u8; 20];
+        self.stream.read_exact(&mut iro_header_bytes)?;
+        let (_, iro_header) = parse_iro_header_v2(&iro_header_bytes)?;
+        Ok(iro_header)
+    }
+
+    pub fn read_iro_entries(&mut self, iro_header: &IroHeader) -> Result<Vec<IroEntry>, Error> {
+        let mut iro_entries: Vec<IroEntry> = Vec::new();
+        for _ in 0..iro_header.num_files {
+            let mut entry_len_bytes = [0u8; 2];
+            self.stream.read_exact(&mut entry_len_bytes)?;
+            let entry_len = u16::from_le_bytes(entry_len_bytes);
+
+            let mut entry_bytes = vec![0u8; entry_len as usize - 2];
+            self.stream.read_exact(entry_bytes.as_mut())?;
+
+            let (_, iro_entry) = parse_iro_entry_v2(iro_header, &entry_bytes)?;
+            iro_entries.push(iro_entry);
+        }
+        Ok(iro_entries)
+    }
+
+    pub fn seek_and_read_file_entry<W: Write>(
+        &mut self,
+        iro_entry: &IroEntry,
+        writer: &mut W
+    ) -> Result<(), Error> {
+        let mut buf_reader = BufReader::new(&mut self.stream);
+        buf_reader.seek(std::io::SeekFrom::Start(iro_entry.offset))?;
+        let mut entry_buffer = buf_reader.take(iro_entry.data_len as u64);
+        match iro_entry.flags {
+            FileFlags::LzssCompressed => compression::lzss_decompress(&mut entry_buffer, writer)?,
+            FileFlags::LzmaCompressed => compression::lzma_decompress(&mut entry_buffer, writer)?,
+            _ => {
+                std::io::copy(&mut entry_buffer, writer)?;
+            }
+        };
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add a public API to read IROs using a IO stream

```rust
use iroga::error::Error;
use iroga::iro_archive::IroArchive;
use std::fs::File;
use std::io::BufWriter;
use std::path::Path;

let iro_file = File::open(Path::new("foobar.iro"))?;
let mut iro_archive = IroArchive::open(iro_file);
let iro_header = iro_archive.read_header()?;
let iro_entries = iro_archive.read_iro_entries(&iro_header)?;

for iro_entry in iro_entries {
    let mut buf_writer = BufWriter::new(Vec::new());
    iro_archive.seek_and_read_file_entry(&iro_entry, &mut buf_writer)?;
}
```